### PR TITLE
Question

### DIFF
--- a/src/lecture-3.md
+++ b/src/lecture-3.md
@@ -17,9 +17,14 @@ Every sheaf $F$ on $C$ is representable by $F(G)$ with the above action.
 
 But then there is a covering of the form $G\to U$ (given by choosing an element $u\in U$ and letting $G$ act). The sheaf property says that $F(U)$ is idenfied with the the equalizer of $$F(G)\rightrightarrows F(G\times_U G).$$ Having chosen $u$, let's write $U = G/H$ for $H$ a subgroup of $G$. Two elements of $G$ map to the same element of $G/H$ if and only if they are in the same coset. Thus, an element of $G\times_U G$ has the form $(g, gh)$ for some $h\in H$. This gives an isomorphism of $G$-sets $$G\times_U G\to G\times H,$$ where the $H$ factor in the latter has a trivial $G$-action. In other words, $$G\times_U G\cong \sqcup_{h\in H} G$$ as $G$-sets. This admits a right $H$-action that simply permutes the factors.
 
-By the sheaf property, we conclude that 
+By the sheaf property, we conclude that
 $$F(G\times_U G)\cong \prod_{h\in H} F(G).$$
-What are the maps $F(G)\to \prod_HF(G)$? The first one is the diagonal map, while the second one is the product of the maps $F(G)\to F(G)$ given by the right action of $H$. The equalizer of the maps is precisely the $H$-invariant part of $F(G)$.(Question from Hao: Why is the first map diagonal and second map as claimed?)
+What are the maps $F(G)\to \prod_HF(G)$? The first one is the diagonal map, while the second one is the product of the maps $F(G)\to F(G)$ given by the right action of $H$. The equalizer of the maps is precisely the $H$-invariant part of $F(G)$.(Question from Hao: Why is the first map diagonal and second map as claimed? )
+
+Answer(Hao): Let $\varphi: G \times H \to G \times_U \G : (g,h) \mapsto (g,gh)$. It is a isomorphism of $G$-sets. Let $\pi_1, \pi_2$ be the two projections
+from $G \times_U G$. Then $\pi_1 \circ \varphi(g,h) = g$ and $\pi_2 \circ \varphi(g,h) = gh$. Under the identification $\Phi: F(G \times H ) \cong \prod_H F(G)$,
+each factor on the right hand side is the image of $F(G \times \{h\})$ for some $h$. But $G \times {h}$ is isomorphic to $G$ canonically and we used this
+canonical isomorphism to define $\Phi$, so the first map $F(G) \to F(G\times_U G)$ is the diagonal. The second map on the h-piece of $\prod_H F(G)$ induced from $g (\mapsto (g,h)) \mapsto gh$. Hence it corresponds to the action of $h^{-1}$ on $F(G)$. So the second map is $F(G)$ hitted with all elements of $H$ on the right.
 
 What is $\Hom_C(G/H, F(G))$? Well, $\Hom_C(G, S)$ for any $G$-set $S$ is the same as $S$, so $\Hom_C(G/H, F(G))\subset F(G)$. It is the subset consisting of elements of $F(G)$ that are fixed by $H$, that is, $\alpha\in F(G)$ such that for all $h\in H$, the map $g\mapsto gh^{-1}$ sends $\alpha$ to $\alpha$. Call this $F(G)^{H}$.
 
@@ -33,7 +38,7 @@ Given a topological space $X$, we have the category of open subsets, $\Open(X)$.
 
 We can also consider the slice category $\Top_{/X}$ of all topological spaces over $X$, like $Y\to X$. A covering is a collection of $X$-maps $\{U_i\to U\}$ that form a covering of $U$ in the usual way. This is called the *big site* of $X$.
 
-There are two natural functors 
+There are two natural functors
 $$\Top_{/X}\to\Sh(\Open(X))$$
 and
 $$\Top_{/X}\to\Sh(\Top_{/X}).$$


### PR DESCRIPTION
I added a question in lecture3 for Max to answer. I don't get it why the two maps from F(G) to \prod_{H}F(G) 
are as claimed, one diagonal and the other given by H-actions. 
